### PR TITLE
Customizing MemCache logs and Changing condition for Printing Redis logs

### DIFF
--- a/lib/time_bandits.rb
+++ b/lib/time_bandits.rb
@@ -15,6 +15,7 @@ module TimeBandits
     autoload :MemCache,          'time_bandits/time_consumers/mem_cache'
     autoload :Memcached,         'time_bandits/time_consumers/memcached'
     autoload :Dalli,             'time_bandits/time_consumers/dalli'
+    autoload :CustomDalli,       'time_bandits/time_consumers/custom_dalli'
     autoload :Redis,             'time_bandits/time_consumers/redis'
     autoload :Sequel,            'time_bandits/time_consumers/sequel'
     autoload :Beetle,            'time_bandits/time_consumers/beetle'

--- a/lib/time_bandits/monkey_patches/client.rb
+++ b/lib/time_bandits/monkey_patches/client.rb
@@ -1,6 +1,6 @@
 # Add this line to your ApplicationController (app/controllers/application_controller.rb)
 # to enable logging for memcached:
-# time_bandit TimeBandits::TimeConsumers::Client
+# time_bandit TimeBandits::TimeConsumers::Dalli
 
 require 'dalli'
 

--- a/lib/time_bandits/monkey_patches/client.rb
+++ b/lib/time_bandits/monkey_patches/client.rb
@@ -34,6 +34,7 @@ module Dalli
         end
       end
     end
+
     alias_method :get_without_benchmark, :get
     alias_method :get, :get_with_benchmark
 
@@ -43,7 +44,9 @@ module Dalli
         set_without_benchmark(*args)
       end
     end
+
     alias_method :set_without_benchmark, :set
     alias_method :set, :set_with_benchmark
+
   end
 end

--- a/lib/time_bandits/monkey_patches/client.rb
+++ b/lib/time_bandits/monkey_patches/client.rb
@@ -1,0 +1,49 @@
+# Add this line to your ApplicationController (app/controllers/application_controller.rb)
+# to enable logging for memcached:
+# time_bandit TimeBandits::TimeConsumers::Client
+
+require 'dalli'
+
+raise "Dalli needs to be loaded before monkey patching it" unless defined?(Dalli)
+
+
+module Dalli
+  class Client
+    def get_with_benchmark(key, options=nil)
+      ActiveSupport::Notifications.instrument("get.dalli") do |payload|
+        if key.is_a?(Array)
+          payload[:reads] = (num_keys = key.size)
+          results = []
+          begin
+            results = get_without_benchmark(key, options)
+          rescue Dalli::NotFound
+          end
+          payload[:misses] = num_keys - results.size
+          results
+        else
+          val = nil
+          payload[:reads] = 1
+          payload[:misses] = 0
+          begin
+            val = get_without_benchmark(key, options)
+          rescue Dalli::NotFound
+          end
+          payload[:misses] = 1  if val.is_a?(NullObject) || val.blank?
+          payload[:key] = key
+          val
+        end
+      end
+    end
+    alias_method :get_without_benchmark, :get
+    alias_method :get, :get_with_benchmark
+
+    def set_with_benchmark(*args)
+      ActiveSupport::Notifications.instrument("set.dalli") do |payload|
+        payload[:key] = args[0]
+        set_without_benchmark(*args)
+      end
+    end
+    alias_method :set_without_benchmark, :set
+    alias_method :set, :set_with_benchmark
+  end
+end

--- a/lib/time_bandits/monkey_patches/client.rb
+++ b/lib/time_bandits/monkey_patches/client.rb
@@ -1,6 +1,6 @@
 # Add this line to your ApplicationController (app/controllers/application_controller.rb)
 # to enable logging for memcached:
-# time_bandit TimeBandits::TimeConsumers::Dalli
+# time_bandit TimeBandits::TimeConsumers::DalliCustom
 
 require 'dalli'
 
@@ -14,20 +14,14 @@ module Dalli
         if key.is_a?(Array)
           payload[:reads] = (num_keys = key.size)
           results = []
-          begin
-            results = get_without_benchmark(key, options)
-          rescue Dalli::NotFound
-          end
+          results = get_without_benchmark(key, options)
           payload[:misses] = num_keys - results.size
           results
         else
           val = nil
           payload[:reads] = 1
           payload[:misses] = 0
-          begin
-            val = get_without_benchmark(key, options)
-          rescue Dalli::NotFound
-          end
+          val = get_without_benchmark(key, options)
           payload[:misses] = 1  if val.is_a?(NullObject) || val.blank?
           payload[:key] = key
           val

--- a/lib/time_bandits/time_consumers/custom_dalli.rb
+++ b/lib/time_bandits/time_consumers/custom_dalli.rb
@@ -1,0 +1,63 @@
+if Rails::VERSION::STRING =~ /\A4.[0123]/
+  require "time_bandits/monkey_patches/active_support_cache_store"
+end
+
+module TimeBandits::TimeConsumers
+  class CustomDalli < BaseConsumer
+    prefix :memcache
+    fields :time, :calls, :misses, :reads, :writes
+    format "CustomDalli: %.3f(%dr,%dm,%dw,%dc)", :time, :reads, :misses, :writes, :calls
+
+    if Rails::VERSION::STRING >= "4.0" && Rails::VERSION::STRING < "4.2" && Rails.cache.class.respond_to?(:instrument=)
+      # Rails 4 mem_cache_store (which uses dalli internally), unlike dalli_store, is not instrumented by default
+      def reset
+        Rails.cache.class.instrument = true
+        super
+      end
+    end
+
+    class Subscriber < ActiveSupport::LogSubscriber
+      # cache events are: read write fetch_hit generate delete read_multi increment decrement clear
+      def cache_read(event)
+        i = cache(event)
+        i.reads += 1
+        i.misses += 1 unless event.payload[:hit]
+      end
+
+      def cache_read_multi(event)
+        i = cache(event)
+        i.reads += event.payload[:key].size
+      end
+
+      def cache_write(event)
+        i = cache(event)
+        i.writes += 1
+      end
+
+      def cache_increment(event)
+        i = cache(event)
+        i.writes += 1
+      end
+
+      def cache_decrement(event)
+        i = cache(event)
+        i.writes += 1
+      end
+
+      def cache_delete(event)
+        i = cache(event)
+        i.writes += 1
+      end
+
+      private
+      def cache(event)
+        i = CustomDalli.instance
+        i.time += event.duration
+        i.calls += 1
+        i
+      end
+    end
+    Subscriber.attach_to :active_support
+  end
+
+end

--- a/lib/time_bandits/time_consumers/custom_dalli.rb
+++ b/lib/time_bandits/time_consumers/custom_dalli.rb
@@ -1,63 +1,57 @@
-if Rails::VERSION::STRING =~ /\A4.[0123]/
-  require "time_bandits/monkey_patches/active_support_cache_store"
-end
+# a time consumer implementation for memcached(Dalli)
+# install into application_controller.rb with the line
+#
+#   time_bandit TimeBandits::TimeConsumers::CustomDalli
+#
+require "time_bandits/monkey_patches/client"
+module TimeBandits
+  module TimeConsumers
+    class CustomDalli < BaseConsumer
+      prefix :memcache
+      fields :time, :calls, :misses, :reads, :writes, :key
+      format "MC: %.3fms(%dr,%dm,%dw,%dc)", :time, :reads, :misses, :writes, :calls
+      class Subscriber < ActiveSupport::LogSubscriber
+        #get and set are the different cache events instrumented here
+        def get(event)
+          i = CustomDalli.instance
+          i.time += event.duration
+          i.calls += 1
+          payload = event.payload
+          i.reads += payload[:reads]
+          i.misses += payload[:misses]
+          return unless logger.debug?
+          message = event.payload[:misses] == 0 ? "Hit:" : "Miss:"
+          logging(event, message) if logging_allowed?
+        end
 
-module TimeBandits::TimeConsumers
-  class CustomDalli < BaseConsumer
-    prefix :memcache
-    fields :time, :calls, :misses, :reads, :writes
-    format "CustomDalli: %.3f(%dr,%dm,%dw,%dc)", :time, :reads, :misses, :writes, :calls
+        def set(event)
+          i = CustomDalli.instance
+          i.time += event.duration
+          i.calls += 1
+          i.writes += 1
+          return unless logger.debug?
+          message = "Write:"
+          logging(event, message) if logging_allowed?
+        end
 
-    if Rails::VERSION::STRING >= "4.0" && Rails::VERSION::STRING < "4.2" && Rails.cache.class.respond_to?(:instrument=)
-      # Rails 4 mem_cache_store (which uses dalli internally), unlike dalli_store, is not instrumented by default
-      def reset
-        Rails.cache.class.instrument = true
-        super
+        private
+        #The instrumentation logging is enabled via time_bandits verbose mode and it is default for development environment
+        def logging(event, message)
+          name = "%s (%.2fms)" % ["MemCache", event.duration]
+          cmd = event.payload[:key]
+          # output = "  #{color(name, CYAN, true)}"
+          output = "  #{name}"
+          output << " [#{message}#{cmd.to_s}]"
+          debug output
+        end
+
+        def logging_allowed?
+          ENV["TIME_BANDITS_VERBOSE"] == "true" ? true : false
+        end
       end
+
+      Subscriber.attach_to :dalli
+
     end
-
-    class Subscriber < ActiveSupport::LogSubscriber
-      # cache events are: read write fetch_hit generate delete read_multi increment decrement clear
-      def cache_read(event)
-        i = cache(event)
-        i.reads += 1
-        i.misses += 1 unless event.payload[:hit]
-      end
-
-      def cache_read_multi(event)
-        i = cache(event)
-        i.reads += event.payload[:key].size
-      end
-
-      def cache_write(event)
-        i = cache(event)
-        i.writes += 1
-      end
-
-      def cache_increment(event)
-        i = cache(event)
-        i.writes += 1
-      end
-
-      def cache_decrement(event)
-        i = cache(event)
-        i.writes += 1
-      end
-
-      def cache_delete(event)
-        i = cache(event)
-        i.writes += 1
-      end
-
-      private
-      def cache(event)
-        i = CustomDalli.instance
-        i.time += event.duration
-        i.calls += 1
-        i
-      end
-    end
-    Subscriber.attach_to :active_support
   end
-
 end

--- a/lib/time_bandits/time_consumers/custom_dalli.rb
+++ b/lib/time_bandits/time_consumers/custom_dalli.rb
@@ -19,7 +19,6 @@ module TimeBandits
           payload = event.payload
           i.reads += payload[:reads]
           i.misses += payload[:misses]
-          return unless logger.debug?
           message = event.payload[:misses] == 0 ? "Hit:" : "Miss:"
           logging(event, message) if logging_allowed?
         end
@@ -29,7 +28,6 @@ module TimeBandits
           i.time += event.duration
           i.calls += 1
           i.writes += 1
-          return unless logger.debug?
           message = "Write:"
           logging(event, message) if logging_allowed?
         end

--- a/lib/time_bandits/time_consumers/dalli.rb
+++ b/lib/time_bandits/time_consumers/dalli.rb
@@ -1,7 +1,7 @@
-# a time consumer implementation for memchached
+# a time consumer implementation for memchached(Dalli)
 # install into application_controller.rb with the line
 #
-#   time_bandit TimeBandits::TimeConsumers::Memcached
+#   time_bandit TimeBandits::TimeConsumers::Dalli
 #
 
 require "time_bandits/monkey_patches/client"

--- a/lib/time_bandits/time_consumers/dalli.rb
+++ b/lib/time_bandits/time_consumers/dalli.rb
@@ -6,7 +6,7 @@ module TimeBandits::TimeConsumers
   class Dalli < BaseConsumer
     prefix :memcache
     fields :time, :calls, :misses, :reads, :writes
-    format "CustomDalli: %.3f(%dr,%dm,%dw,%dc)", :time, :reads, :misses, :writes, :calls
+    format "Dalli: %.3f(%dr,%dm,%dw,%dc)", :time, :reads, :misses, :writes, :calls
 
     if Rails::VERSION::STRING >= "4.0" && Rails::VERSION::STRING < "4.2" && Rails.cache.class.respond_to?(:instrument=)
       # Rails 4 mem_cache_store (which uses dalli internally), unlike dalli_store, is not instrumented by default

--- a/lib/time_bandits/time_consumers/dalli.rb
+++ b/lib/time_bandits/time_consumers/dalli.rb
@@ -1,63 +1,57 @@
-if Rails::VERSION::STRING =~ /\A4.[0123]/
-  require "time_bandits/monkey_patches/active_support_cache_store"
-end
+# a time consumer implementation for memchached
+# install into application_controller.rb with the line
+#
+#   time_bandit TimeBandits::TimeConsumers::Memcached
+#
 
-module TimeBandits::TimeConsumers
-  class Dalli < BaseConsumer
-    prefix :memcache
-    fields :time, :calls, :misses, :reads, :writes
-    format "Dalli: %.3f(%dr,%dm,%dw,%dc)", :time, :reads, :misses, :writes, :calls
+require "time_bandits/monkey_patches/client"
 
-    if Rails::VERSION::STRING >= "4.0" && Rails::VERSION::STRING < "4.2" && Rails.cache.class.respond_to?(:instrument=)
-      # Rails 4 mem_cache_store (which uses dalli internally), unlike dalli_store, is not instrumented by default
-      def reset
-        Rails.cache.class.instrument = true
-        super
+module TimeBandits
+  module TimeConsumers
+    class Dalli < BaseConsumer
+      prefix :memcache
+      fields :time, :calls, :misses, :reads, :writes, :key
+      format "MC: %.3fms(%dr,%dm,%dw,%dc)", :time, :reads, :misses, :writes, :calls
+
+      class Subscriber < ActiveSupport::LogSubscriber
+        def get(event)
+          i = Dalli.instance
+          i.time += event.duration
+          i.calls += 1
+          payload = event.payload
+          i.reads += payload[:reads]
+          i.misses += payload[:misses]
+          return unless logger.debug?
+          message = event.payload[:misses] == 0 ? "Hit:" : "Miss:"
+          logging(event,message) if logging_allowed?
+        end
+        def set(event)
+          i = Dalli.instance
+          i.time += event.duration
+          i.calls += 1
+          i.writes += 1
+          return unless logger.debug?
+          message = "Write:"
+          logging(event,message) if logging_allowed?
+        end
+
+        private
+        #The instrumentation logging is enabled via time_bandits verbose mode and it is default for development environment
+        def logging(event,message)
+          name = "%s (%.2fms)" % ["MemCache", event.duration]
+          cmd = event.payload[:key]
+          # output = "  #{color(name, CYAN, true)}"
+          output = "  #{name}"
+          output << " [#{message}#{cmd.to_s}]"
+          debug output
+        end
+        def logging_allowed?
+          ENV["TIME_BANDITS_VERBOSE"] = "true" if Rails.env.development?
+          ENV["TIME_BANDITS_VERBOSE"] == "true" ? true : false
+        end
+
       end
+      Subscriber.attach_to :dalli
     end
-
-    class Subscriber < ActiveSupport::LogSubscriber
-      # cache events are: read write fetch_hit generate delete read_multi increment decrement clear
-      def cache_read(event)
-        i = cache(event)
-        i.reads += 1
-        i.misses += 1 unless event.payload[:hit]
-      end
-
-      def cache_read_multi(event)
-        i = cache(event)
-        i.reads += event.payload[:key].size
-      end
-
-      def cache_write(event)
-        i = cache(event)
-        i.writes += 1
-      end
-
-      def cache_increment(event)
-        i = cache(event)
-        i.writes += 1
-      end
-
-      def cache_decrement(event)
-        i = cache(event)
-        i.writes += 1
-      end
-
-      def cache_delete(event)
-        i = cache(event)
-        i.writes += 1
-      end
-
-      private
-      def cache(event)
-        i = Dalli.instance
-        i.time += event.duration
-        i.calls += 1
-        i
-      end
-    end
-    Subscriber.attach_to :active_support
   end
-
 end

--- a/lib/time_bandits/time_consumers/redis.rb
+++ b/lib/time_bandits/time_consumers/redis.rb
@@ -17,9 +17,6 @@ module TimeBandits
           i = Redis.instance
           i.time += event.duration
           i.calls += 1 #count redis round trips, not calls
-
-          return unless logger.debug?
-
           name = "%s (%.2fms)" % ["Redis", event.duration]
           cmds = event.payload[:commands]
 

--- a/lib/time_bandits/time_consumers/redis.rb
+++ b/lib/time_bandits/time_consumers/redis.rb
@@ -56,7 +56,6 @@ module TimeBandits
         # presence of message in sidekiq job queues
 
         def logging_allowed?
-          ENV["TIME_BANDITS_VERBOSE"] = "true" if Rails.env.development?
           (!::Sidekiq.server? || (::Sidekiq.server? && Thread.current[:message_uuid])) && ENV["TIME_BANDITS_VERBOSE"] == "true" ? true : false
         end
       end

--- a/lib/time_bandits/time_consumers/redis.rb
+++ b/lib/time_bandits/time_consumers/redis.rb
@@ -10,7 +10,7 @@ module TimeBandits
     class Redis < BaseConsumer
       prefix :redis
       fields :time, :calls
-      format "Redis: %.3f(%d)", :time, :calls
+      format "Redis: %.3fms(%dc)", :time, :calls
 
       class Subscriber < ActiveSupport::LogSubscriber
         def request(event)
@@ -49,10 +49,14 @@ module TimeBandits
         end
 
         private
-        # The debug logs are printed only for the foreground jobs and for the background jobs with job id
+
+        #The Logging can be enabled in verbose mode and it is default for development environment
+        # The debug logs are printed only for the foreground jobs and for the background jobs with job id.
         # Because the log lines increases exponentially for the background jobs while doing redis calls for the
         # presence of message in sidekiq job queues
+
         def logging_allowed?
+          ENV["TIME_BANDITS_VERBOSE"] = "true" if Rails.env.development?
           (!::Sidekiq.server? || (::Sidekiq.server? && Thread.current[:message_uuid])) && ENV["TIME_BANDITS_VERBOSE"] == "true" ? true : false
         end
       end


### PR DESCRIPTION
**JIRA Id(s)** :  FD-16049

**Description** : 
The Application Log format has been changed to print the instrumentation of MemCache such as  number of calls made,  number of hits and misses, number of writes  and duration it took to complete the request. The logs are printed when the verbose mode is enabled and it is default for development environment. 
The Instrumentation is done for get and set methods in MemCache-Client. Both the App-Cache and Controller-Cache is measured in same time_bandits initializer. Since the Dalli store used for instrumenting Controller-Cache is internally calling the MemCache client only.
