### PR TITLE
INFRA 1152 - Printing Duplicate Calls Count for Memcache in Application.log

### DIFF
--- a/lib/dalli_duplicate_counter.rb
+++ b/lib/dalli_duplicate_counter.rb
@@ -1,0 +1,28 @@
+module DalliDuplicateCounter
+  include CustomRequestStore
+
+  def self.key_already_exists?(key, operation)
+    counter = get_counter(operation)
+    if counter[key].present?
+      return true
+    else
+     counter.store(key,1)
+      return false
+    end
+  end
+
+  
+  private
+  def get_counter(operation)
+    if "read".eql? operation
+      return CustomRequestStore.store[:duplicate_read_counter] ||
+          CustomRequestStore.store[:duplicate_read_counter] = {}
+    elsif "write".eql? operation
+      return CustomRequestStore.store[:duplicate_write_counter] ||
+          CustomRequestStore.store[:duplicate_write_counter] = {}
+    elsif "delete".eql? operation
+      return CustomRequestStore.store[:duplicate_delete_counter] ||
+          CustomRequestStore.store[:duplicate_delete_counter] = {}
+    end
+  end
+end

--- a/lib/dalli_duplicate_counter.rb
+++ b/lib/dalli_duplicate_counter.rb
@@ -13,7 +13,7 @@ module DalliDuplicateCounter
 
   
   private
-  def get_counter(operation)
+  def self.get_counter(operation)
     if "read".eql? operation
       return CustomRequestStore.store[:duplicate_read_counter] ||
           CustomRequestStore.store[:duplicate_read_counter] = {}

--- a/lib/time_bandits/monkey_patches/client.rb
+++ b/lib/time_bandits/monkey_patches/client.rb
@@ -21,9 +21,9 @@ module Dalli
           val = nil
           payload[:reads] = 1
           payload[:misses] = 0
+          payload[:key] = key
           val = get_without_benchmark(key, options)
           payload[:misses] = 1  if val.is_a?(NullObject) || val.blank?
-          payload[:key] = key
           val
         end
       end

--- a/lib/time_bandits/rack/logger.rb
+++ b/lib/time_bandits/rack/logger.rb
@@ -55,7 +55,7 @@ module TimeBandits
         completed_info = Thread.current.thread_variable_get(:time_bandits_completed_info)
         additions = completed_info[1] if completed_info
 
-        message = "Completed #{status} #{::Rack::Utils::HTTP_STATUS_CODES[status]} in %.1fms" % run_time
+        message = "Completed #{status} #{::Rack::Utils::HTTP_STATUS_CODES[status]} in %.3fs" % run_time
         message << " (#{additions.join(' | ')})" unless additions.blank?
         info message
       ensure

--- a/lib/time_bandits/time_consumers/custom_dalli.rb
+++ b/lib/time_bandits/time_consumers/custom_dalli.rb
@@ -10,7 +10,7 @@ module TimeBandits
     class CustomDalli < BaseConsumer
       prefix :memcache
       fields :time, :calls, :misses, :reads, :writes, :key, :dup_reads, :dup_writes
-      format "MC: %.3fms(%dr,%dm,%dw,%dc)", :time, :reads, :misses, :writes, :calls, :dup_reads, :dup_writes
+      format "MC: %.3fms(%dr,%dm,%dw,%dc,%ddr,%ddw)", :time, :reads, :misses, :writes, :calls, :dup_reads, :dup_writes
       class Subscriber < ActiveSupport::LogSubscriber
         #get and set are the different cache events instrumented here
         def get(event)
@@ -30,7 +30,7 @@ module TimeBandits
           i.time += event.duration
           i.calls += 1
           i.writes += 1
-          i.dup_writes += 1 if MemcacheDuplicateCounter.key_already_exists?(event.payload[:key], "write")
+          i.dup_writes += 1 if DalliDuplicateCounter.key_already_exists?(event.payload[:key], "write")
           message = "Write:"
           logging(event, message) if logging_allowed?
         end


### PR DESCRIPTION
**JIRA Id(s)** :  INFRA - 1152

**Description** : 
1)In application.log the duplicate calls for Memcache (read and write) is printed by making use of dedicated counters. The count is printed for each and every requests. 
2)The time unit for total duration was wrongly printed as milliseconds, that bug is addressed and it has been changed to seconds.
3)For printing the Hit and miss log in Memcache, a new condition check is added to address the edge case.( ie: When errors like Memcache unmarshall error is thrown, it is silently caught and recorded as hit previously. Now that is changed to record as  miss and logged.)

